### PR TITLE
Update UnifiNetworkMaps.ps1

### DIFF
--- a/UnifiNetworkMaps.ps1
+++ b/UnifiNetworkMaps.ps1
@@ -68,7 +68,6 @@ $unifiDevices = Invoke-RestMethod -Uri "$UnifiBaseUri/s/$($site.name)/stat/devic
 
 $UAPs = $unifiDevices.data | Where-Object {$_.type -contains "uap"}
 
-$Accesspoints = @()
 $Accesspoints = foreach ($UAP in $UAPs){
     [PSCustomObject] @{
         APName = $UAP.name
@@ -80,8 +79,8 @@ $Accesspoints = foreach ($UAP in $UAPs){
 #switches
 
 $USWs = $unifiDevices.data | Where-Object {$_.type -contains "usw"}
-$switches = @()
-$switches = foreach ($USW in $USWs){
+
+[Array] $switches = foreach ($USW in $USWs){
     [PSCustomObject] @{
         SwitchName = $USW.name
         SwitchIP = $USW.ip


### PR DESCRIPTION
You don't need to define array first. When you have $Variable = foreach ... it will create it and put all items into it. There's one thing to know thou. If you don't add the [Array] before, if it will be  just 1 element this will be a string type. If you want it to behave like an array it's important to add the type before it. I've modified two examples giving you two examples.